### PR TITLE
Add socket watch services to fix startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ chmod +x install_gvm.sh
 sudo ./install_gvm.sh 
 ```
 
-Based on koromicha's excellent guide, and thanks to the commenters there as well:
-https://kifarunix.com/install-and-setup-gvm-11-on-ubuntu-20-04/
+Based on [koromicha's excellent guide](https://kifarunix.com/install-and-setup-gvm-11-on-ubuntu-20-04/). Thanks to the commenters there as well:
+
 
 Takes a while to do everything (a couple of hours on my last test).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ chmod +x install_gvm.sh
 sudo ./install_gvm.sh 
 ```
 
-Based on [koromicha's excellent guide](https://kifarunix.com/install-and-setup-gvm-11-on-ubuntu-20-04/). Thanks to the commenters there as well:
+Based on [koromicha's excellent guide](https://kifarunix.com/install-and-setup-gvm-11-on-ubuntu-20-04/). Thanks to the commenters there as well for useful troubleshooting info.
 
 
 Takes a while to do everything (a couple of hours on my last test).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # gvm_install
 A script to install GVM / OpenVAS 11 on Ubuntu 20.04
 
-Usage: sudo ./install_gvm.sh 
+Usage:
 
-Based on koromicha's excellent guide:
-https://kifarunix.com/install-and-setup-gvm-11-on-ubuntu-20-04/?amp
+```
+wget https://raw.githubusercontent.com/yu210148/gvm_install/master/install_gvm.sh
+chmod +x install_gvm.sh
+sudo ./install_gvm.sh 
+```
+
+Based on koromicha's excellent guide, and thanks to the commenters there as well:
+https://kifarunix.com/install-and-setup-gvm-11-on-ubuntu-20-04/
 
 Takes a while to do everything (a couple of hours on my last test).
 
 When creating a task be sure to select the "Created OpenVAS Scanner" from the drop-down.
 
-Works-for-me as of 2020-05-12. Your experience may be different.
-Use at your own risk.
+Tested successfully in a VM on 2020-08-12. Your experience may be different. Use at your own risk.
 
-Licensed under GPLv3 or later
+Licensed under GPLv3 or later.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # gvm_install
 A script to install GVM / OpenVAS 11 on Ubuntu 20.04
 
-Usage:
+Usage (note the text editor - read the script!):
 
 ```
-wget https://raw.githubusercontent.com/yu210148/gvm_install/master/install_gvm.sh
+wget https://raw.githubusercontent.com/<account>/gvm_install/master/install_gvm.sh
+nano install_gvm.sh
 chmod +x install_gvm.sh
 sudo ./install_gvm.sh 
 ```

--- a/install_gvm.sh
+++ b/install_gvm.sh
@@ -272,6 +272,16 @@ echo -e "\n" >> /etc/systemd/system/gvm.service
 echo "[Install]" >> /etc/systemd/system/gvm.service
 echo "WantedBy=multi-user.target" >> /etc/systemd/system/gvm.service
 
+echo "[Unit]" > /etc/systemd/system/gvm.path
+echo "Description=Start the OpenVAS GVM service when opsd.sock is available" >> /etc/systemd/system/gvm.path
+echo -e "\n" >> /etc/systemd/system/gvm.path
+echo "[Path]" >> /etc/systemd/system/gvm.path
+echo "PathChanged=/opt/gvm/var/run/ospd.sock" >> /etc/systemd/system/gvm.path
+echo "Unit=gvm.service" >> /etc/systemd/system/gvm.path
+echo -e "\n" >> /etc/systemd/system/gvm.path
+echo "[Install]" >> /etc/systemd/system/gvm.path
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/gvm.path
+
 echo "[Unit]" > /etc/systemd/system/gsa.service
 echo "Description=Control the OpenVAS GSA service" >> /etc/systemd/system/gsa.service
 echo "After=openvas.service" >> /etc/systemd/system/gsa.service
@@ -288,10 +298,21 @@ echo -e "\n" >> /etc/systemd/system/gsa.service
 echo "[Install]" >> /etc/systemd/system/gsa.service
 echo "WantedBy=multi-user.target" >> /etc/systemd/system/gsa.service
 
+echo "[Unit]" > /etc/systemd/system/gsa.path
+echo "Description=Start the OpenVAS GSA service when gvmd.sock is available" >> /etc/systemd/system/gsa.path
+echo -e "\n" >> /etc/systemd/system/gsa.path
+echo "[Path]" >> /etc/systemd/system/gsa.path
+echo "PathChanged=/opt/gvm/var/run/gvmd.sock" >> /etc/systemd/system/gsa.path
+echo "Unit=gsa.service" >> /etc/systemd/system/gsa.path
+echo -e "\n" >> /etc/systemd/system/gsa.path
+echo "[Install]" >> /etc/systemd/system/gsa.path
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/gsa.path
+
+
 systemctl daemon-reload
 systemctl enable --now openvas
-systemctl enable --now gvm
-systemctl enable --now gsa 
+systemctl enable --now gvm.{path,service}
+systemctl enable --now gsa.{path,service}
 
 
 # REMIND USER TO CHANGE DEFAULT PASSWORD


### PR DESCRIPTION
Added systemd path definitions which only start gvm and gsa services once the openvas socket is open (i.e. NVTs are loaded)