### PR TITLE
Adjust upgrade command to not require input

### DIFF
--- a/install_gvm.sh
+++ b/install_gvm.sh
@@ -29,7 +29,7 @@ fi
 #GVMVERSION='11'
 
 apt-get update
-apt-get upgrade
+apt-get upgrade -y 
 useradd -r -d /opt/gvm -c "GVM (OpenVAS) User" -s /bin/bash gvm
 mkdir /opt/gvm
 chown gvm:gvm /opt/gvm


### PR DESCRIPTION
The script is blocked waiting for input after selecting the version to install - if the apt upgrade finds packages, it will ask to install them instead of proceeding automatically. This commit ensures that the script proceeds to install the upgrades without halting.