### PR TITLE
Remount tmp partition in servers with hardening

### DIFF
--- a/install_gvm.sh
+++ b/install_gvm.sh
@@ -96,7 +96,7 @@ else
     exit 1
 fi
 
-TMP_IS_MOUNTED=$(sudo df |grep /tmp$|wc -l)
+TMP_IS_MOUNTED=$(df |grep /tmp$|wc -l)
 
 if [ $TMP_IS_MOUNTED -eq 0 ]; then
 	echo "Re-mounting partition /tmp"


### PR DESCRIPTION
Some servers with hardening settings, block script execution in tmp. This code snippet is to remount tmp to avoid this problem that occurs with installing postgres