### PR TITLE
change update order, update-vt-info run as gvm

### DIFF
--- a/install_gvm.sh
+++ b/install_gvm.sh
@@ -96,15 +96,6 @@ else
     exit 1
 fi
 
-TMP_IS_MOUNTED=$(df |grep /tmp$|wc -l)
-
-if [ $TMP_IS_MOUNTED -eq 0 ]; then
-	echo "Re-mounting partition /tmp"
-	sleep 3
-	sudo mount -o remount,defaults /tmp
-	echo "After installation, check if your partition /tmp is mounted correctly"
-fi
-
 apt-get update
 apt-get upgrade -y 
 useradd -r -d /opt/gvm -c "GVM (OpenVAS) User" -s /bin/bash gvm

--- a/install_gvm.sh
+++ b/install_gvm.sh
@@ -622,14 +622,10 @@ fi
 # Update data from the feed servers
 ##############################################################################
 #update NVT feed
-su gvm -c /opt/gvm/bin/greenbone-nvt-sync
-/opt/gvm/sbin/openvas --update-vt-info
+su gvm -c "/opt/gvm/bin/greenbone-nvt-sync"
+su gvm -c "/opt/gvm/sbin/openvas --update-vt-info"
 # give the db a chance to update
 echo "Sleeping for 5 minutes to let the DB finish the NVT update"
-sleep 300
-# update GVMD_DATA
-su gvm -c "/opt/gvm/sbin/greenbone-feed-sync --type GVMD_DATA"
-echo "Sleeping for 5 minutes to let the DB finish the GVMD_DATA update"
 sleep 300
 # update SCAP
 su gvm -c "/opt/gvm/sbin/greenbone-feed-sync --type SCAP"
@@ -638,6 +634,10 @@ sleep 300
 # update CERT
 su gvm -c "/opt/gvm/sbin/greenbone-feed-sync --type CERT"
 echo "Sleeping for 5 minutes to let the DB finish the CERT update"
+sleep 300
+# update GVMD_DATA
+su gvm -c "/opt/gvm/sbin/greenbone-feed-sync --type GVMD_DATA"
+echo "Sleeping for 5 minutes to let the DB finish the GVMD_DATA update"
 sleep 300
 ############################################################################
 


### PR DESCRIPTION
https://greenbone.github.io/docs/latest/21.04/source-build/index.html#performing-an-initial-feed-synchronization says the feed should be updated in a specific order
ie
sudo -u gvm greenbone-nvt-sync
sudo -u gvm greenbone-feed-sync --type SCAP
sudo -u gvm greenbone-feed-sync --type CERT
sudo -u gvm greenbone-feed-sync --type GVMD_DATA
Changes the script to reflect this